### PR TITLE
Release 0.5 - Skill leveling events, dynamic bot response system, flat disk saving interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ logs/
 # Only the translation source shall be tracked in repository
 resources/translations/*
 !resources/translations/source.json
+
+
+# Editor settings
+.vscode

--- a/lib/hypixel/hypixelv2.py
+++ b/lib/hypixel/hypixelv2.py
@@ -1,0 +1,131 @@
+import asyncio
+import threading
+import time
+import uuid
+import datetime
+import queue
+import requests
+import json
+from enum import Enum, unique
+
+exit_flag = 0
+
+@unique
+class RequestType(Enum):
+    PROFILE = "PROFILE"     # Get a specific profile by profile uuid
+    PROFILES = "PROFILES"   # Get all profiles from a player by playername
+    GETUUID = "GETUUID"     # Get players UUID from name
+    TESTKEY = "TESTKEY"     # Get api key information
+    NOOP = "NOOP"           # Do not call any api, but simulate the call for timing tests
+
+    @classmethod
+    def has_value(cls, value):
+        return str(value) in cls._value2member_map_
+
+    def describe(self):
+        return self.name, self.value
+
+    def __str__(self):
+        return f'{self.value}'
+
+
+class SBAPIRequest():
+
+    def __init__(self, type, params):
+        self.id = uuid.uuid4()
+        self.type = type
+        self.params = params
+        if not self.check_type():
+            raise ValueError()
+
+    def check_type(self):
+        return RequestType.has_value(self.type)
+
+    def __str__(self):
+        return f"SBAPIRequest<{self.id}, {self.type}, {self.params}>"
+
+
+class APICall(threading.Thread):
+    def __init__(self, id, output, urlcall):
+        threading.Thread.__init__(self)
+        self.output = output
+        self.urlcall = urlcall
+        self.id = id
+
+    def run(self):
+        response = requests.get(self.urlcall)
+        if response.status_code == 200:
+            self.output[str(self.id)] = json.loads(response.text)
+        else:
+            self.output[str(self.id)] = {'dd_error': True, 'dd_no_200': True}
+
+
+
+class SkyblockAPI(threading.Thread):
+    def __init__(self, hypixel_api_key):
+        threading.Thread.__init__(self)
+        self.hypixel_api_key = hypixel_api_key
+        self.input = queue.Queue()
+        self.output = {}
+        self.api_calls = 0
+        self.api_reset_times = []
+        self.shall_stop = False
+
+    async def request(self, sb_api_request, timeout):
+        start_time = time.time()
+        self.input.put(sb_api_request)
+        while True:
+            if time.time() - start_time >= 5:
+                return {'dd_error': True, 'dd_timeout': True}
+            if str(sb_api_request.id) in self.output:
+                return self.output.pop(str(sb_api_request.id))
+
+    def _consume_item(self, item):
+        if not isinstance(item, SBAPIRequest):
+            raise ValueError("Consumed item is not of type API Request")
+        if item.type == RequestType.GETUUID:
+            callthread = APICall(item.id, self.output, f"https://api.mojang.com/users/profiles/minecraft/{item.params[0]}")
+            callthread.start()
+        elif item.type == RequestType.NOOP:
+            self.api_calls += 1
+            self.api_reset_times.append(time.time() + 123)
+            print(f"{datetime.datetime.now().isoformat()} - NOOP Call {item.id}")
+        elif item.type == RequestType.PROFILES:
+            self.api_calls += 1
+            self.api_reset_times.append(time.time() + 123)
+            callthread = APICall(
+                item.id,
+                self.output,
+                f"https://api.hypixel.net/skyblock/profiles?key={self.hypixel_api_key}&uuid={item.params[0]}"
+            )
+            callthread.start()
+        elif item.type == RequestType.TESTKEY:
+            self.api_calls += 1
+            self.api_reset_times.append(time.time() + 123)
+            callthread = APICall(
+                item.id,
+                self.output,
+                f"https://api.hypixel.net/key?key={self.hypixel_api_key}"
+            )
+        elif item.type == RequestType.PROFILE:
+            self.api_calls += 1
+            self.api_reset_times.append(self.lifetime + 123)
+
+
+    def run(self):
+        while(True):
+            if self.shall_stop and self.input.empty():
+                break
+
+            self.api_calls -= self.api_reset_times.count(time.time())
+
+            while ((not self.input.empty()) and (self.api_calls < 120)):
+                item = self.input.get()
+                if item == "#STOP#":
+                    self.shall_stop = True
+                else:
+                    self._consume_item(item)
+
+            pass
+
+        time.sleep(3) # Sleep to give time to clean up after this thread

--- a/lib/hypixel/hypixelv2.py
+++ b/lib/hypixel/hypixelv2.py
@@ -56,6 +56,7 @@ class APICall(threading.Thread):
         self.id = id
 
     def run(self):
+        print("API: Fetching " + self.urlcall)
         response = requests.get(self.urlcall)
         if response.status_code == 200:
             self.output[str(self.id)] = json.loads(response.text)
@@ -95,11 +96,13 @@ class SkyblockAPI(threading.Thread):
                 "https://api.mojang.com/users/profiles/"
                 + f"minecraft/{item.params[0]}")
             callthread.start()
+
         elif item.type == RequestType.NOOP:
             self.api_calls += 1
             self.api_reset_times.append(time.time() + 123)
             print(f"{datetime.datetime.now().isoformat()} - "
                   + "NOOP Call {item.id}")
+
         elif item.type == RequestType.PROFILES:
             self.api_calls += 1
             self.api_reset_times.append(time.time() + 123)
@@ -110,6 +113,7 @@ class SkyblockAPI(threading.Thread):
                 + f"{self.hypixel_api_key}&uuid={item.params[0]}"
             )
             callthread.start()
+
         elif item.type == RequestType.TESTKEY:
             self.api_calls += 1
             self.api_reset_times.append(time.time() + 123)
@@ -118,6 +122,8 @@ class SkyblockAPI(threading.Thread):
                 self.output,
                 f"https://api.hypixel.net/key?key={self.hypixel_api_key}"
             )
+            callthread.start()
+
         elif item.type == RequestType.PROFILE:
             self.api_calls += 1
             self.api_reset_times.append(time.time() + 123)

--- a/lib/hypixel/hypixelv2.py
+++ b/lib/hypixel/hypixelv2.py
@@ -117,7 +117,14 @@ class SkyblockAPI(threading.Thread):
             )
         elif item.type == RequestType.PROFILE:
             self.api_calls += 1
-            self.api_reset_times.append(self.lifetime + 123)
+            self.api_reset_times.append(time.time() + 123)
+            callthread = APICall(
+                item.id,
+                self.output,
+                "https://api.hypixel.net/skyblock/profile?key="
+                + f"{self.hypixel_api_key}&profile={item.params[0]}"
+            )
+            callthread.start()
 
     def run(self):
         while(True):

--- a/lib/hypixel/hypixelv2.py
+++ b/lib/hypixel/hypixelv2.py
@@ -70,11 +70,11 @@ class SkyblockAPI(threading.Thread):
         self.api_reset_times = []
         self.shall_stop = False
 
-    async def request(self, sb_api_request, timeout):
+    async def request(self, sb_api_request, timeout=5):
         start_time = time.time()
         self.input.put(sb_api_request)
         while True:
-            if time.time() - start_time >= 5:
+            if time.time() - start_time >= timeout:
                 return {'dd_error': True, 'dd_timeout': True}
             if str(sb_api_request.id) in self.output:
                 return self.output.pop(str(sb_api_request.id))

--- a/lib/hypixel/hypixelv2.py
+++ b/lib/hypixel/hypixelv2.py
@@ -79,6 +79,9 @@ class SkyblockAPI(threading.Thread):
             if str(sb_api_request.id) in self.output:
                 return self.output.pop(str(sb_api_request.id))
 
+    def stop(self):
+        self.shall_stop = True
+
     def _consume_item(self, item):
         if not isinstance(item, SBAPIRequest):
             raise ValueError("Consumed item is not of type API Request")
@@ -125,10 +128,7 @@ class SkyblockAPI(threading.Thread):
 
             while ((not self.input.empty()) and (self.api_calls < 120)):
                 item = self.input.get()
-                if item == "#STOP#":
-                    self.shall_stop = True
-                else:
-                    self._consume_item(item)
+                self._consume_item(item)
 
             pass
 

--- a/lib/hypixel/hypixelv2.py
+++ b/lib/hypixel/hypixelv2.py
@@ -31,8 +31,11 @@ class RequestType(Enum):
 
 class SBAPIRequest():
 
-    def __init__(self, type, params):
-        self.id = uuid.uuid4()
+    def __init__(self, type, params, uid=None):
+        if uid is None:
+            self.id = uuid.uuid4()
+        else:
+            self.id = uid
         self.type = type
         self.params = params
         if not self.check_type():

--- a/resources/translations/source.json
+++ b/resources/translations/source.json
@@ -3,7 +3,6 @@
     "en": "AlexxBot",
     "de": "AlexxBot"
   },
-
   "language.meta.name.unlocalized": {
     "en": "English",
     "de": "German"
@@ -12,7 +11,6 @@
     "en": "English",
     "de": "Deutsch"
   },
-
   "dcbot.readymessage": {
     "en": "Client successfully logged in as '{client}'",
     "de": "Client erfolgreich eingeloggt als '{client}'"
@@ -25,16 +23,14 @@
     "en": "Unable to log the desired message: Channel not found",
     "de": "Nachricht konnte nicht geloggt werden: <Channel not found>"
   },
-
   "dcbot.features.title": {
     "en": "Features",
     "de": "Funktionen"
   },
   "dcbot.features.features": {
-    "en":":small_orange_diamond:Automatic dynamic voice channel system\n:small_orange_diamond:Apply for our Hypixel community guild\n:small_orange_diamond:Warn system for staff\n:small_orange_diamond:Counting Channel\n:small_orange_diamond:Create custom commands at runtime\n:small_orange_diamond:Check HGG API with information about Hypixel Skyblock player reports",
-    "de":":small_orange_diamond:Automatisches System für dynamische Voicechannel\n:small_orange_diamond:Bewerbungen für unsere Hypixel Communitygilde\n:small_orange_diamond:Verwarntools für das Team\n:small_orange_diamond:Counting Channel\n:small_orange_diamond:Eigene Befehle dynamisch erstellen\n:small_orange_diamond:Integration für HGG mit Communityreports über Hypixel Skyblock-Spieler"
+    "en": ":small_orange_diamond:Automatic dynamic voice channel system\n:small_orange_diamond:Apply for our Hypixel community guild\n:small_orange_diamond:Warn system for staff\n:small_orange_diamond:Counting Channel\n:small_orange_diamond:Create custom commands at runtime\n:small_orange_diamond:Check HGG API with information about Hypixel Skyblock player reports\n:small_orange_diamond:Hypixel Skyblock Leveling Challenges",
+    "de": ":small_orange_diamond:Automatisches System für dynamische Voicechannel\n:small_orange_diamond:Bewerbungen für unsere Hypixel Communitygilde\n:small_orange_diamond:Verwarntools für das Team\n:small_orange_diamond:Counting Channel\n:small_orange_diamond:Eigene Befehle dynamisch erstellen\n:small_orange_diamond:Integration für HGG mit Communityreports über Hypixel Skyblock-Spieler\n:small_orange_diamond:Hypixel Skyblock Leveling Challenges"
   },
-
   "dcbot.contributor.title": {
     "en": "Contributors",
     "de": "Programmierer"
@@ -43,8 +39,6 @@
     "en": ":small_orange_diamond: <@285720078031388673>\n:small_orange_diamond: <@497789163555389441>",
     "de": ":small_orange_diamond: <@285720078031388673>\n:small_orange_diamond: <@497789163555389441>"
   },
-
-
   "init.stage0.successful": {
     "en": "Init stage 0 of 3 fulfilled successfully, as it is an automatic stage. Use command `init` while in any init stage to see help on current stage. Normal commands doesn't work until initialization is finished. The default command short-prefix is `$` until you define your own prefix in init stage 1.",
     "de": "Init-Stufe 0 von 3 wurde erfolgreich beendet, da es sich um eine automatische Stufe handelt. Der Befehl 'init' zeigt dir jederzeit während der Initialisierung, was nun gemacht werden muss. Das Standard-Präfix für Befehle ist `$`, bis ein eigenes Präfix in Stufe 1 definiert wird."
@@ -77,12 +71,10 @@
     "en": "Init finished. The bot is now set up to work in production.",
     "de": "Initialisierung beendet. Der Bot ist nun bereit für den Einsatz!"
   },
-
   "command.addcmdchan.meta.description": {
     "en": "Add an existing channel to the list of command-allowed channels for users",
     "de": "Einen Channel für Botbefehle von diesem Bot freischalten"
   },
-
   "command.apply.meta.description": {
     "en": "Apply for the Hypixel community guild from AlexxOffi",
     "de": "Bewirb dich für die Hypixel Communitygilde von AlexxOffi"
@@ -115,12 +107,10 @@
     "en": "This player has no profile named \"{profile}\".",
     "de": "Dieser Spieler hat kein Profil mit dem Namen \"{profile}\"."
   },
-
   "command.chanset.meta.description": {
     "en": "Set the channel ID for a Key-Identifier",
     "de": "Weise einem Key-Identifier einen bestimmten Channel zu"
   },
-
   "command.faq.meta.description": {
     "en": "Send an embed with a both custom texts as title and description. Useful for FAQs",
     "de": "Erstell ein Embed mit benutzerdefiniertem Titel und Text. Nützlich für FAQs"
@@ -129,7 +119,6 @@
     "en": "Please use exactly 2 parameters: `faq \"question\" \"answer\"`",
     "de": "Es sind nur exakt 2 Parameter erlaubt: `faq \"Frage\" \"Antwort\"`"
   },
-
   "command.help.meta.description": {
     "en": "Show the help for this bot",
     "de": "Zeige diese Hilfe an"
@@ -138,7 +127,6 @@
     "en": "The current command prefix is `{shortprefix}`. This prefix is always omitted in help information.\nFor command-specific help use `help <command>`.",
     "de": "Das aktuelle Prefix für diesen Bot ist `{shortprefix}`. Dieses Prefix wird in der Hilfe nicht weiterhin angezeigt.\nFür Hilfe zu einem bestimmten Befehl schreibe `help <Befehl>`."
   },
-
   "command.info.meta.description": {
     "en": "Shows information about this bot",
     "de": "Zeige Informationen über diesen Bot an"
@@ -183,7 +171,6 @@
     "en": "[Create issue on GitHub](https://github.com/DerDomee/discordbot-alexxoffi/issues/new/choose) or contact me (<@285720078031388673>) via Discord!",
     "de": "[Erstell einen Issue auf GitHub](https://github.com/DerDomee/discordbot-alexxoffi/issues/new/choose) oder schreib mir (<@285720078031388673>) auf Discord!"
   },
-
   "command.language.meta.description": {
     "en": "Manage the language in which the bot speaks to you",
     "de": "Verwalte die Sprache mit welcher der Bot schreibt."
@@ -196,17 +183,14 @@
     "en": "Language updated to `{lang}`",
     "de": "Die Sprache wurde zu `{lang}` geändert."
   },
-
   "command.printarg.meta.description": {
     "en": "A debug command that tests the internal string-lexer that is used to lex and parse a message content into a command-argument-stack",
     "de": "Ein Debug-Befehl, welcher den internen ArgV-Parser `stavlex` testet und das Ergebnis zeigt."
   },
-
   "command.rmcmdchan.meta.description": {
     "en": "Remove a channel from the list of command-allowed channels for users",
     "de": "Einen Channel für Botbefehle von diesem Bot wieder deaktivieren"
   },
-
   "command.server.meta.description": {
     "en": "Shows information about this server",
     "de": "Zeige Informationen über diesen Server"
@@ -231,17 +215,14 @@
     "en": "{member_count} online",
     "de": "{member_count} online"
   },
-
   "command.setprefix.meta.description": {
     "en": "Set a new command prefix for this bot",
     "de": "Setzt ein neues Prefix für den Bot"
   },
-
   "command.stop.meta.description": {
     "en": "Stop this bot",
     "de": "Stoppt den Bot"
   },
-
   "command.voice.meta.description": {
     "en": "Control the dynamic voice channel you are currently connected to, if you are its owner.",
     "de": "Steuerung des dynamischen Voice-Channels, dessen Besitzer du bist"
@@ -362,7 +343,6 @@
     "en": "Manually close this channel. (It gets closed automatically if everyone leaves)",
     "de": "Schließt den Channel manuell. (Der Channel schließt sich auch, wenn er leer ist)"
   },
-
   "command.warn.meta.description": {
     "en": "Warn a user on the discord",
     "de": "Warnt einen User auf dem Discord"
@@ -379,25 +359,20 @@
     "en": "{mention}, as you disabled direct messages from everyone, I ping you here to let you know: **You have been warned!** Use the command `user` in a bot channel on the server to see further information on the warn! Warns usually expire after 1-3 months, but are saved for eternity!",
     "de": "{mention}, da du private Nachrichten von mir auf diesem Server deaktiviert hast, wirst du hier gepingt: **Du wurdest von einem Teammtiglied gewarnt!** Du bekommst mehr Informationen über den Ban mit dem Befehl `user`. Verwarnungen laufen nach 1-3 Monaten ab, aber werden für immer gespeichert!"
   },
-
   "event.voice.inithelp.embed.title": {
     "en": "Welcome to your own voice channel!",
     "de": "Willkommen in deinem Voicechannel!"
   },
-
   "event.voice.inithelp.embed.description": {
     "en": "You can use following commands in this channel only:",
     "de": "Du kannst folgende Commands in diesem Channel verwenden, um deinen Voicechat zu moderieren:"
   },
-
   "event.voice.inithelp.embed.more_info.title": {
     "en": "More information: ",
     "de": "Mehr Informationen:"
   },
-
   "event.voice.inithelp.embed.more_info.value": {
     "en": "**1.** If the owner leaves without transferring ownership, a new owner is randomly chosen.\n**2.** As soon as the channel is empty, it gets removed automatically.\n**3.** When a user disconnects from a private channel, he still can see the channel and reconnect. To prevent reconnecting, the owner must kick other users with `voice kick`.\n**4.** You can use 'channel editing' commands **up to 2 times altogether** due to anti-spam.",
     "de": "**1.** Wenn der Channelbesitzer den Voicechannel verlässt, wird zufällig ein neuer Besitzer bestimmt.\n**2.** Wenn der Channel leer ist, wird er automatisch geschlossen.\n**3.**Wenn ein User einen privaten Voicechannel verlässt, bleibt der Channel für ihn trotzdem sichtbar. Der Besitzer muss ihn mit `voice kick` manuell kicken.\n**4.** Um Spam zu verhindern, können Commands, die den Channel editieren, nur insgesamt zwei mal benutzt werden."
   }
-
 }

--- a/runscripts/bot.py
+++ b/runscripts/bot.py
@@ -1,8 +1,12 @@
 #!/usr/bin/python
-import os
-import sys
-from src.database import sqlengine  # noqa: F401
 from src.dcbot import client
+import sys
+import os
+from pathlib import Path
+
+Path('./data/xp_events/').mkdir(parents=True, exist_ok=True)
+
+from src.database import sqlengine  # noqa: F401
 
 discord_bot_token = os.getenv('DD_DISCORD_BOTTOKEN', default=None)
 

--- a/runscripts/bot.py
+++ b/runscripts/bot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 import os
 import sys
-from src.database import sqlengine
+from src.database import sqlengine  # noqa: F401
 from src.dcbot import client
 
 discord_bot_token = os.getenv('DD_DISCORD_BOTTOKEN', default=None)

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -50,6 +50,9 @@ key_color_danger = 0xEF3D3D
 # Common quick-access variables for the bot, may be None if not initialized yet
 main_guild = None
 
+# This variable is set to False on first on_ready call
+is_initial_start = True
+
 # Voice channel object:
 bot_voice_channels = []
 

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -293,7 +293,8 @@ class ChallengeEvent():
             embed.add_field(name="Event Type", value=self.type.name)
             embed.add_field(name="Status", value="Ended")
             total_participants = str(
-                len(self.get_total_players()) - len(self.get_pending_players))
+                len(self.get_total_players()) - len(
+                    self.get_pending_players()))
             errored_participants = str(len(self.get_errored_players()))
             disqualified_participants = str(
                 len(self.get_disqualified_players()))

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -228,6 +228,10 @@ class ChallengeEvent():
         await message.edit(content=None, embed=self.get_embed())
         return
 
+    def get_type_name(self):
+        if self.status == ChallengeStatus.OPEN:
+            return "(Type HIDDEN)"
+        return self.type.name
 
     def get_leaderboard(self):
         players = self.get_finished_players()
@@ -252,7 +256,7 @@ class ChallengeEvent():
     def get_embed(self, language="en", announcement=True):
         if self.status == ChallengeStatus.OPEN:
             embed = Embed(title=self.title, description=f"`{self.uuid}`")
-            embed.add_field(name="Event Type", value="(HIDDEN)")
+            embed.add_field(name="Event Type", value=self.get_type_name())
             embed.add_field(name="Status", value="Open to join")
             embed.add_field(
                 name="Join until",
@@ -288,7 +292,7 @@ class ChallengeEvent():
 
         elif self.status == ChallengeStatus.PENDING:
             embed = Embed(title=self.title, description=f"`{self.uuid}`")
-            embed.add_field(name="Event Type", value=self.type.name)
+            embed.add_field(name="Event Type", value=self.get_type_name())
             embed.add_field(name="Status", value="Starts soon (Can not join)")
             embed.add_field(
                 name="Event starts",
@@ -310,12 +314,12 @@ class ChallengeEvent():
 
         elif self.status == ChallengeStatus.STARTING:
             embed = Embed(title=self.title, description=f"`{self.uuid}`")
-            embed.add_field(name="Event Type", value=self.type.name)
+            embed.add_field(name="Event Type", value=self.get_type_name())
             embed.add_field(name="Status", value="Currently starting...")
 
         elif self.status == ChallengeStatus.RUNNING:
             embed = Embed(title=self.title, description=f"`{self.uuid}`")
-            embed.add_field(name="Event Type", value=self.type.name)
+            embed.add_field(name="Event Type", value=self.get_type_name())
             embed.add_field(name="Status", value="Running")
             total_participants = str(len(self.get_total_players()))
             pending_participants = str(len(self.get_pending_players()))
@@ -340,12 +344,12 @@ class ChallengeEvent():
 
         elif self.status == ChallengeStatus.ENDING:
             embed = Embed(title=self.title, description=f"`{self.uuid}`")
-            embed.add_field(name="Event Type", value=self.type.name)
+            embed.add_field(name="Event Type", value=self.get_type_name())
             embed.add_field(name="Status", value="Ending... (Gathering data)")
 
         elif self.status == ChallengeStatus.ENDED:
             embed = Embed(title=self.title, description=f"UUID: `{self.uuid}`")
-            embed.add_field(name="Event Type", value=self.type.name)
+            embed.add_field(name="Event Type", value=self.get_type_name())
             embed.add_field(name="Status", value="Ended")
             embed.add_field(
                 name="Leaderboard",
@@ -357,13 +361,13 @@ class ChallengeEvent():
             errored_participants = str(len(self.get_errored_players()))
             disqualified_participants = str(
                 len(self.get_disqualified_players()))
-            active_participants = str(len(self.get_active_players()))
+            finished_participants = str(len(self.get_finished_players()))
             part_text = f"`+{total_participants:>3}` Accepted entries\n" \
                 + f"`-{disqualified_participants:>3}` Disqualified " \
                 + "(Deactivated API)\n" \
                 + f"`-{errored_participants:>3}` Error during data " \
                 + "collection (Sorry!)\n" \
-                + f"`={active_participants:>3}` Successfully participated"
+                + f"`={finished_participants:>3}` Successfully participated"
             embed.add_field(
                 name="Participants",
                 value=part_text)
@@ -375,7 +379,7 @@ class ChallengeEvent():
 
         elif self.status == ChallengeStatus.DISCARDED:
             embed = Embed(title=self.title, description=f"`{self.uuid}`")
-            embed.add_field(name="Event Type", value=self.type.name)
+            embed.add_field(name="Event Type", value=self.get_type_name())
             embed.add_field(name="Status", value="Event discarded")
 
         else:

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -152,6 +152,13 @@ class ChallengeEvent():
         self.status = ChallengeStatus.DISCARDED
         await self.update_challenge_embed()
         challenge_scheduler.removeTask(self)
+        self.archive_to_disk()
+
+    def archive_to_disk(self):
+        with open(f"./data/xp_events/{self.uuid}.json", 'w') as f:
+            ser = self.serialize()
+            print(ser)
+            f.write(ser)
 
     def get_pending_players(self):
         pending_players = []

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -1,4 +1,5 @@
 import functools
+from enum import Enum, unique
 from src.database import dbcommon
 from src.dcbot import client
 from src.translation import transget
@@ -56,6 +57,37 @@ hypixel_api = None
 # Is the bot currently shutting down? This is used for disabling events
 # while cleaning up the server and is set from inside the 'stop' command
 is_bot_stopping = False
+
+
+# Stat types for Hypixel skyblock skill leveling challenges
+# Name "Skill leveling challenges" is bad - it supports all stats,
+# not only skills
+@unique
+class StatTypes(Enum):
+    FARMING = "experience_skill_farming"
+    COMBAT = "experience_skill_combat"
+    MINING = "experience_skill_mining"
+    FORAGING = "experience_skill_foraging"
+    FISHING = "experience_skill_fishing"
+    ENCHANTING = "experience_skill_enchanting"
+    ALCHEMY = "experience_skill_alchemy"
+    TAMING = "experience_skill_taming"
+    CARPENTRY = "experience_skill_carpentry"
+    RUNECRAFTING = "experience_skill_runecrafting"
+    CATACOMBS = "dungeons/dungeon_types/catacombs/experience"
+    SLAYER_REVENANT = "slayer_bosses/zombie/xp"
+    SLAYER_TARANTULA = "slayer_bosses/spider/xp"
+    SLAYER_SVEN = "slayer_bosses/wolf/xp"
+
+    @classmethod
+    def has_value(cls, value):
+        return str(value) in cls._value2member_map_
+
+    def describe(self):
+        return self.name, self.value
+
+    def __str__(self):
+        return f"{self.value}"
 
 
 async def get_member_by_id_or_ping(selector):

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -304,6 +304,19 @@ class ChallengeScheduler(threading.Thread):
 challenge_scheduler = None
 
 
+def get_profile_challenge_stat(profile_data, player_uuid, challenge_type):
+    try:
+        player_data = profile_data['members'][player_uuid]
+        type_path = challenge_type.value.split('/')
+        stat_data = player_data
+        while len(type_path) > 0:
+            stat_data = stat_data[type_path.pop()]
+    except Exception:
+        return None
+    else:
+        return stat_data
+
+
 async def get_member_by_id_or_ping(selector):
     user_id = str(selector).lstrip("<@!").lstrip("<@").rstrip(">")
     guild = main_guild

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -310,7 +310,7 @@ def get_profile_challenge_stat(profile_data, player_uuid, challenge_type):
         type_path = challenge_type.value.split('/')
         stat_data = player_data
         while len(type_path) > 0:
-            stat_data = stat_data[type_path.pop()]
+            stat_data = stat_data[type_path.pop(0)]
     except Exception:
         return None
     else:

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -224,7 +224,7 @@ class ChallengeEvent():
     def get_embed(self, language="en", announcement=True):
         if self.status == ChallengeStatus.OPEN:
             embed = Embed(title=self.title, description=f"`{self.uuid}`")
-            embed.add_field(name="Event Type", value=self.type.name)
+            embed.add_field(name="Event Type", value="(HIDDEN)")
             embed.add_field(name="Status", value="Open to join")
             embed.add_field(
                 name="Join until",

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -422,7 +422,7 @@ class ChallengeEvent():
             'end_time': self.end_time.timestamp(),
             'pay_in': self.pay_in,
             'auto_accept': self.auto_accept,
-            'anouncement_message_id': self.announcement_message_id,
+            'announcement_message_id': self.announcement_message_id,
             'announcement_channel_id': self.announcement_channel_id,
             'players': self.players
         }, indent=2)

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -50,6 +50,9 @@ registered_bot_commands = []
 # Currently registered message processors
 registered_message_processors = []
 
+# Hypixel API
+hypixel_api = None
+
 # Is the bot currently shutting down? This is used for disabling events
 # while cleaning up the server and is set from inside the 'stop' command
 is_bot_stopping = False

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -94,6 +94,7 @@ class StatTypes(Enum):
     def __str__(self):
         return f"{self.value}"
 
+
 # Challenge types for Hypixel skyblock skill leveling challenges
 @unique
 class ChallengeStatus(Enum):

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -2,6 +2,7 @@ import functools
 import json
 import threading
 import time
+import os.path
 from datetime import datetime
 from discord import Embed
 from enum import Enum, unique
@@ -463,6 +464,28 @@ class ChallengeScheduler(threading.Thread):
 
     def removeTask(self, task):
         self.scheduled_tasks.remove(task)
+
+    def save_all_tracked(self):
+        if len(self.scheduled_tasks) == 0:
+            return
+        save_object = {}
+        for challenge in self.scheduled_tasks:
+            save_object[challenge.uuid] = challenge.serialize()
+        with open('./data/tracked_challenges.json', 'w') as f:
+            f.write(json.dumps(save_object, indent=2))
+
+    def load_all_tracked(self):
+        if not os.path.isfile('./data/tracked_challenges.json'):
+            return
+        with open('./data/tracked_challenges.json', 'r') as f:
+            data = f.read()
+            read_data = json.loads(data) if data != "" else {}
+        print(read_data)
+        for chall_uuid in read_data:
+            print(chall_uuid)
+            print(read_data[chall_uuid])
+            challenge = ChallengeEvent.deserialize(read_data[chall_uuid])
+            self.addTask(challenge)
 
     def getTask(self, uuid):
         for task in self.scheduled_tasks:

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -2,7 +2,7 @@ import functools
 import json
 import threading
 import time
-import os.path
+import os
 from datetime import datetime
 from discord import Embed
 from enum import Enum, unique
@@ -157,9 +157,7 @@ class ChallengeEvent():
 
     def archive_to_disk(self):
         with open(f"./data/xp_events/{self.uuid}.json", 'w') as f:
-            ser = self.serialize()
-            print(ser)
-            f.write(ser)
+            f.write(self.serialize())
 
     def get_pending_players(self):
         pending_players = []
@@ -480,10 +478,8 @@ class ChallengeScheduler(threading.Thread):
         with open('./data/tracked_challenges.json', 'r') as f:
             data = f.read()
             read_data = json.loads(data) if data != "" else {}
-        print(read_data)
+            os.remove('./data/tracked_challenges.json')
         for chall_uuid in read_data:
-            print(chall_uuid)
-            print(read_data[chall_uuid])
             challenge = ChallengeEvent.deserialize(read_data[chall_uuid])
             self.addTask(challenge)
 

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -211,6 +211,13 @@ class ChallengeEvent():
                 disqualified_players.append(player)
         return disqualified_players
 
+    def get_finished_players(self):
+        finished_players = []
+        for player in self.players:
+            if player['state'] == "FINISHED":
+                finished_players.append(player)
+        return finished_players
+
     async def update_challenge_embed(self):
         message = await get_message_by_id(
             self.announcement_channel_id, self.announcement_message_id)

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -638,7 +638,6 @@ class ChallengeScheduler(threading.Thread):
         with open('./data/tracked_challenges.json', 'r') as f:
             data = f.read()
             read_data = json.loads(data) if data != "" else {}
-            os.remove('./data/tracked_challenges.json')
         for chall_uuid in read_data:
             challenge = ChallengeEvent.deserialize(read_data[chall_uuid])
             self.addTask(challenge)

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -221,6 +221,27 @@ class ChallengeEvent():
         await message.edit(content=None, embed=self.get_embed())
         return
 
+
+    def get_leaderboard(self):
+        players = self.get_finished_players()
+        lb_text = "```Error while calculating leaderboard...\n\nSorry!```"
+        lb_entries = []
+        try:
+            players = sorted(
+                players, key=lambda k: k['stat_delta'], reverse=True)
+            if len(players) > 15:
+                players = players[:15]
+            for index, player in enumerate(players):
+                lb_entries.append(
+                    f"{index+1}. {player['mcname']}: "
+                    + f"+{player['stat_delta']:.0f}")
+        except Exception:
+            return lb_text
+        else:
+            lb_text = "\n".join(lb_entries)
+            lb_text = "```" + lb_text + "```"
+        return lb_text
+
     def get_embed(self, language="en", announcement=True):
         if self.status == ChallengeStatus.OPEN:
             embed = Embed(title=self.title, description=f"`{self.uuid}`")
@@ -319,6 +340,10 @@ class ChallengeEvent():
             embed = Embed(title=self.title, description=f"UUID: `{self.uuid}`")
             embed.add_field(name="Event Type", value=self.type.name)
             embed.add_field(name="Status", value="Ended")
+            embed.add_field(
+                name="Leaderboard",
+                value=self.get_leaderboard(),
+                inline=False)
             total_participants = str(
                 len(self.get_total_players()) - len(
                     self.get_pending_players()))
@@ -335,10 +360,6 @@ class ChallengeEvent():
             embed.add_field(
                 name="Participants",
                 value=part_text)
-            embed.add_field(
-                name="Leaderboard",
-                value="```NOT YET IMPLEMENTED\n\n\nSorry!```",
-                inline=False)
             embed.add_field(
                 name="See your results",
                 value="Use command `chall results` to see your own results "

--- a/src/dcbot/botcommon.py
+++ b/src/dcbot/botcommon.py
@@ -536,9 +536,9 @@ class ChallengeEvent():
         elif self.status == ChallengeStatus.PENDING:
             self.status = ChallengeStatus.STARTING
             client.loop.call_soon_threadsafe(updateAnnouncementWrapper)
-            # Artificial sleep to test tick-announcement-updates
-            time.sleep(10)
-            # Remove this sleep when gather_start_player_data() is implemented!
+            time.sleep(2)
+            # Artificial sleep to let discord update the message embed before
+            # thread locks
             self.gather_start_player_data()
             self.status = ChallengeStatus.RUNNING
             client.loop.call_soon_threadsafe(updateAnnouncementWrapper)
@@ -549,9 +549,9 @@ class ChallengeEvent():
         elif self.status == ChallengeStatus.RUNNING:
             self.status = ChallengeStatus.ENDING
             client.loop.call_soon_threadsafe(updateAnnouncementWrapper)
-            # Artificial sleep to test tick-announcement-updates
-            time.sleep(10)
-            # Remove this sleep when gather_end_player_data() is implemented!
+            time.sleep(2)
+            # Artificial sleep to let discord update the message embed before
+            # thread locks
             self.gather_end_player_data()
             self.status = ChallengeStatus.ENDED
             client.loop.call_soon_threadsafe(updateAnnouncementWrapper)

--- a/src/dcbot/commands/_user.py
+++ b/src/dcbot/commands/_user.py
@@ -64,7 +64,7 @@ async def invoke(message, arg_stack, botuser):
         await message.channel.send(embed=embed)
         return True
     elif len(arg_stack) == 2:
-        if botuser.user_permission_level <= botcommon.key_permlevel_moderator:
+        if botuser.user_permission_level < botcommon.key_permlevel_moderator:
             await message.channel.send("No Permission.")
             return False
         dcmember = await _get_member_efficiently(arg_stack[1], message.guild)

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -577,7 +577,7 @@ async def _await_join_confirmation(
             content=f"{message.author.mention}, your API seems to be "
             + "disabled. You cannot join with disabled API and you will get "
             + "disqualified if you disable your API before or during the "
-            + "event!")
+            + "event! If you think this is an error, contact an admin!")
         return False
     profilename = selected_profile['cute_name']
     challname = selected_challenge.title
@@ -585,7 +585,6 @@ async def _await_join_confirmation(
     embed.add_field(name="MC-Name", value=mcname, inline=False)
     embed.add_field(name="Profile", value=profilename, inline=False)
     embed.add_field(name="Challenge", value=challname, inline=False)
-    embed.add_field(name="Stat preview", value=stat_preview, inline=False)
     embed.add_field(
         name="Warning",
         value="If you disable your API at any point from now until the end of "

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -1,7 +1,6 @@
+from asyncio import TimeoutError
 from src.dcbot import botcommon
 from src.dcbot import client
-import asyncio
-from src.translation import transget
 from lib.hypixel.hypixelv2 import SBAPIRequest, RequestType
 
 CMD_METADATA = {
@@ -9,28 +8,36 @@ CMD_METADATA = {
     'required_channels': [botcommon.key_bot_userchannel,
                           botcommon.key_bot_adminchannel]}
 
-NUMBER_REACTIONS = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣']
+NUMBER_REACTIONS = ['1️⃣', '2️⃣', '3️⃣',
+                    '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣']
 
 
-async def _get_available_profiles(message, arg_stack, botuser, response_message):
+async def _get_available_profiles(
+        message, arg_stack, botuser, response_message):
     uuidrequest = SBAPIRequest(RequestType.GETUUID, (arg_stack[2],))
     uuid = await botcommon.hypixel_api.request(uuidrequest, 5)
     if 'dd_error' in uuid:
-        await response_message.edit(content=f"{message.author.mention}, this player does not exist.")
+        await response_message.edit(
+            content=f"{message.author.mention}, this player does not exist.")
         return False
     uuid = uuid['id']
     profilesrequest = SBAPIRequest(RequestType.PROFILES, (uuid,))
     profiles = await botcommon.hypixel_api.request(profilesrequest, 5)
     if 'dd_error' in profiles:
-        await response_message.edit(content=f"{message.author.mention}, there was an error while getting your skyblock profiles. Try again later.")
+        await response_message.edit(
+            content=f"{message.author.mention}, there was an error while "
+            + "getting your skyblock profiles. Try again later.")
         return False
-    if profiles['profiles'] == None:
-        await response_message.edit(content=f"{message.author.mention}, this player does not have a skyblock profile.")
+    if profiles['profiles'] is None:
+        await response_message.edit(
+            content=f"{message.author.mention}, this "
+            + "player does not have a skyblock profile.")
         return False
     return list(profiles['profiles'])
 
 
-async def _get_selected_profile(message, arg_stack, botuser, response_message, available_profiles):
+async def _get_selected_profile(
+        message, arg_stack, botuser, response_message, available_profiles):
     if len(available_profiles) == 1:
         return available_profiles[0]
     available_text = f"{message.author.mention}, please select your profile:"
@@ -43,34 +50,48 @@ async def _get_selected_profile(message, arg_stack, botuser, response_message, a
         await response_message.add_reaction(NUMBER_REACTIONS[i])
 
     def pselect_check(reaction, user):
-        return user.id == message.author.id and reaction.message.id == response_message.id and str(reaction) in NUMBER_REACTIONS[:len(available_profiles)]
+        return user.id == message.author.id and \
+            reaction.message.id == response_message.id and str(
+                reaction) in NUMBER_REACTIONS[:len(available_profiles)]
 
     try:
-        reaction, reactionuser = await client.wait_for('reaction_add', check=pselect_check, timeout=30.0)
-    except asyncio.TimeoutError:
+        reaction, reactionuser = await client.wait_for(
+            'reaction_add', check=pselect_check, timeout=30.0
+        )
+    except TimeoutError:
         await response_message.clear_reactions()
-        await response_message.edit(content=f"{message.author.mention}, session closed!")
+        await response_message.edit(
+            content=f"{message.author.mention}, session closed!"
+        )
         return False
     else:
-        selected_profile = available_profiles[NUMBER_REACTIONS.index(str(reaction))]
+        selected_profile = available_profiles[NUMBER_REACTIONS.index(
+            str(reaction))]
         await response_message.clear_reactions()
         return selected_profile
     return False
 
+
 async def _create_challenge(message, arg_stack, botuser):
-    response_message = await message.channel.send(f"{message.author.mention}, creating...")
+    response_message = await message.channel.send(
+        f"{message.author.mention}, creating...")
 
 
 async def _join_challenge(message, arg_stack, botuser):
-    response_message = await message.channel.send(f"{message.author.mention}, fetching...")
-    available_profiles = await _get_available_profiles(message, arg_stack, botuser, response_message)
+    response_message = await message.channel.send(
+        f"{message.author.mention}, fetching...")
+    available_profiles = await _get_available_profiles(
+        message, arg_stack, botuser, response_message)
     if available_profiles is False:
         return False
-    selected_profile = await _get_selected_profile(message, arg_stack, botuser, response_message, available_profiles)
+    selected_profile = await _get_selected_profile(
+        message, arg_stack, botuser, response_message, available_profiles)
     if selected_profile is False:
         return False
 
-    await response_message.edit(content=f"{message.author.mention}, selected profile: {selected_profile['cute_name']}")
+    await response_message.edit(
+        content=f"{message.author.mention}, selected profile: "
+        + f"{selected_profile['cute_name']}")
     return True
 
 

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -9,28 +9,28 @@ CMD_METADATA = {
     'required_channels': [botcommon.key_bot_userchannel,
                           botcommon.key_bot_adminchannel]}
 
-NUMBER_REACTIONS = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣', ]
+NUMBER_REACTIONS = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣']
 
 
-async def _get_available_profiles(message, arg_stack, botuser):
-    uuidrequest = SBAPIRequest(RequestType.GETUUID, (arg_stack[1],))
+async def _get_available_profiles(message, arg_stack, botuser, response_message):
+    uuidrequest = SBAPIRequest(RequestType.GETUUID, (arg_stack[2],))
     uuid = await botcommon.hypixel_api.request(uuidrequest, 5)
     if 'dd_error' in uuid:
-        await message.channel.send(f"{message.author.mention}, this player does not exist.")
+        await response_message.edit(content=f"{message.author.mention}, this player does not exist.")
         return False
     uuid = uuid['id']
     profilesrequest = SBAPIRequest(RequestType.PROFILES, (uuid,))
     profiles = await botcommon.hypixel_api.request(profilesrequest, 5)
     if 'dd_error' in profiles:
-        await message.channel.send(f"{message.author.mention}, there was an error while getting your skyblock profiles. Try again later.")
+        await response_message.edit(content=f"{message.author.mention}, there was an error while getting your skyblock profiles. Try again later.")
         return False
     if profiles['profiles'] == None:
-        await message.channel.send(f"{message.author.mention}, this player does not have a skyblock profile.")
+        await response_message.edit(content=f"{message.author.mention}, this player does not have a skyblock profile.")
         return False
     return list(profiles['profiles'])
 
 
-async def _get_selected_profile(message, arg_stack, botuser, available_profiles):
+async def _get_selected_profile(message, arg_stack, botuser, response_message, available_profiles):
     if len(available_profiles) == 1:
         return available_profiles[0]
     available_text = f"{message.author.mention}, please select your profile:"
@@ -38,35 +38,48 @@ async def _get_selected_profile(message, arg_stack, botuser, available_profiles)
         emote = NUMBER_REACTIONS[index]
         pname = profile['cute_name']
         available_text += f"\n{emote} {pname}"
-    pselector = await message.channel.send(available_text)
+    await response_message.edit(content=available_text)
     for i in range(len(available_profiles)):
-        await pselector.add_reaction(NUMBER_REACTIONS[i])
+        await response_message.add_reaction(NUMBER_REACTIONS[i])
 
     def pselect_check(reaction, user):
-        return user.id == message.author.id and reaction.message.id == pselector.id and str(reaction) in NUMBER_REACTIONS[:len(available_profiles)]
+        return user.id == message.author.id and reaction.message.id == response_message.id and str(reaction) in NUMBER_REACTIONS[:len(available_profiles)]
 
     try:
         reaction, reactionuser = await client.wait_for('reaction_add', check=pselect_check, timeout=30.0)
     except asyncio.TimeoutError:
-        await pselector.delete()
-        await message.channel.send(f"{message.author.mention}, session closed!")
+        await response_message.clear_reactions()
+        await response_message.edit(content=f"{message.author.mention}, session closed!")
         return False
     else:
         selected_profile = available_profiles[NUMBER_REACTIONS.index(str(reaction))]
-        await pselector.delete()
+        await response_message.clear_reactions()
         return selected_profile
     return False
+
+async def _create_challenge(message, arg_stack, botuser):
+    response_message = await message.channel.send(f"{message.author.mention}, creating...")
+
+
+async def _join_challenge(message, arg_stack, botuser):
+    response_message = await message.channel.send(f"{message.author.mention}, fetching...")
+    available_profiles = await _get_available_profiles(message, arg_stack, botuser, response_message)
+    if available_profiles is False:
+        return False
+    selected_profile = await _get_selected_profile(message, arg_stack, botuser, response_message, available_profiles)
+    if selected_profile is False:
+        return False
+
+    await response_message.edit(content=f"{message.author.mention}, selected profile: {selected_profile['cute_name']}")
+    return True
 
 
 @botcommon.requires_perm_level(level=CMD_METADATA['required_permlevel'])
 @botcommon.requires_channel(CMD_METADATA['required_channels'])
 async def invoke(message, arg_stack, botuser):
-    if len(arg_stack) >= 2:
-        available_profiles = await _get_available_profiles(message, arg_stack, botuser)
-        if available_profiles is False:
-            return False
-        selected_profile = await _get_selected_profile(message, arg_stack, botuser, available_profiles)
-        if selected_profile is False:
-            return False
-
-        await message.channel.send(f"{message.author.mention}, selected profile: {selected_profile['cute_name']}")
+    if len(arg_stack) == 2:
+        if arg_stack[1].lower() == "create":
+            return await _create_challenge(message, arg_stack, botuser)
+    elif len(arg_stack) == 3:
+        if arg_stack[1].lower() == "join":
+            return await _join_challenge(message, arg_stack, botuser)

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -779,7 +779,7 @@ async def _get_player_status(message, arg_stack, botuser):
         challenge = data[0]
         player = data[1]
         statmsg += f"\nIn `{challenge.title}` (`{challenge.type.name}`) as "
-        statmsg += f"`{player['mcname']}`, Status: `{player['status']}`"
+        statmsg += f"`{player['mcname']}`, Status: `{player['state']}`"
     await message.channel.send(
         f"{message.author.mention}, you were found in following "
         + f"events:{statmsg}")

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -106,8 +106,8 @@ async def _determine_challenge_start_time(
         message, arg_stack, botuser, response_message):
     await response_message.edit(
         content=f"{message.author.mention}, please enter a start time "
-        + f"for the challenge in following format: `dd.mm.yyyy-hh:mm:ss`. "
-        + f"Examples: ```01.01.2021-00:00:00\n23.07.2022-21:00:00```")
+        + "for the challenge in following format: `dd.mm.yyyy-hh:mm:ss`. "
+        + "Examples: ```01.01.2021-00:00:00\n23.07.2022-21:00:00```")
 
     def timeselect_check(timemessage):
         return timemessage.channel.id == message.channel.id and \
@@ -130,16 +130,16 @@ async def _determine_challenge_start_time(
             except ValueError:
                 await response_message.edit(
                     content=f"{message.author.mention}, wrong time format. "
-                    + f"Please use following format: `dd.mm.yyyy-hh:mm:ss`. "
-                    + f"Examples: ```01.01.2021-00:00:00\n"
-                    + f"23.07.2022-21:00:00```")
+                    + "Please use following format: `dd.mm.yyyy-hh:mm:ss`. "
+                    + "Examples: ```01.01.2021-00:00:00\n"
+                    + "23.07.2022-21:00:00```")
                 continue
             if not dt > datetime.now():
                 await response_message.edit(
                     content=f"{message.author.mention}, time must be in the "
-                    + f"future. Please use following format: "
-                    + f"`dd.mm.yyyy-hh:mm:ss`. Examples: "
-                    + f"```01.01.2021-00:00:00\n23.07.2022-21:00:00```")
+                    + "future. Please use following format: "
+                    + "`dd.mm.yyyy-hh:mm:ss`. Examples: "
+                    + "```01.01.2021-00:00:00\n23.07.2022-21:00:00```")
                 continue
             else:
                 time = dt
@@ -150,8 +150,8 @@ async def _determine_challenge_end_time(
         message, arg_stack, botuser, response_message, start_time):
     await response_message.edit(
         content=f"{message.author.mention}, please enter a end time "
-        + f"for the challenge in following format: `dd.mm.yyyy-hh:mm:ss`. "
-        + f"Examples: ```01.01.2021-00:00:00\n23.07.2022-21:00:00```")
+        + "for the challenge in following format: `dd.mm.yyyy-hh:mm:ss`. "
+        + "Examples: ```01.01.2021-00:00:00\n23.07.2022-21:00:00```")
 
     def timeselect_check(timemessage):
         return timemessage.channel.id == message.channel.id and \
@@ -174,16 +174,16 @@ async def _determine_challenge_end_time(
             except ValueError:
                 await response_message.edit(
                     content=f"{message.author.mention}, wrong time format. "
-                    + f"Please use following format: `dd.mm.yyyy-hh:mm:ss`. "
-                    + f"Examples: ```01.01.2021-00:00:00\n"
-                    + f"23.07.2022-21:00:00```")
+                    + "Please use following format: `dd.mm.yyyy-hh:mm:ss`. "
+                    + "Examples: ```01.01.2021-00:00:00\n"
+                    + "23.07.2022-21:00:00```")
                 continue
             if not dt > start_time:
                 await response_message.edit(
                     content=f"{message.author.mention}, end time must be "
-                    + f"after start time. Please use following format: "
-                    + f"`dd.mm.yyyy-hh:mm:ss`. Examples: "
-                    + f"```01.01.2021-00:00:00\n23.07.2022-21:00:00```")
+                    + "after start time. Please use following format: "
+                    + "`dd.mm.yyyy-hh:mm:ss`. Examples: "
+                    + "```01.01.2021-00:00:00\n23.07.2022-21:00:00```")
                 continue
             else:
                 time = dt
@@ -216,7 +216,7 @@ async def _get_payin_coins(message, arg_stack, botuser, response_message):
             except ValueError:
                 await response_message.edit(
                     content=f"{message.author.mention}, please only enter an "
-                    + f"integer number for pay-in. Enter `0` for no pay-in")
+                    + "integer number for pay-in. Enter `0` for no pay-in")
                 continue
             payin = needed_coins
     return payin

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -856,7 +856,7 @@ async def get_help(argstack, botuser, sp):
               + f"\n`{sp}chall results` - See your results in a past "
               + "event"
               + f"\n\n`{sp}chall create` - Create a new challenge event "
-              + f"(Admins only)"
+              + "(Admins only)"
               + f"\n`{sp}chall discard` - Discard an event, as if it "
               + "never happened (Admins only)"
               + f"\n`{sp}chall accept` - Accept a player entry in an "

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -651,8 +651,20 @@ async def _join_challenge(message, arg_stack, botuser):
         selected_challenge, mcuuid, mcname)
     if confirmation is None or confirmation is False:
         return False
-    #       then, let him confirm the data and actually join
-    # TODO: Update the challenges' announcement embed
+
+    player_data = {
+        'mcname': mcname,
+        'mcuuid': mcuuid,
+        'discordid': message.author.id,
+        'state': "ACCEPTED" if selected_challenge.auto_accept else "PENDING"
+    }
+    selected_challenge.players.append(player_data)
+    await selected_challenge.update_challenge_embed()
+
+    await response_message.edit(
+        content=f"{message.author.mention}, successfully joined the "
+        + "challenge!")
+
     return True
 
 

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -764,8 +764,25 @@ async def _discard_challenge(message, arg_stack, botuser):
 
 
 async def _get_player_status(message, arg_stack, botuser):
-    # TODO: Get all currently tracked challenges that the player is found in
-    # TODO: Show the current status of the player for all challenges
+    in_event = []
+    for challenge in botcommon.challenge_scheduler.getAllTasks():
+        player = challenge.get_player(message.author.id)
+        if player is None:
+            continue
+        in_event.append((challenge, player))
+    if len(in_event) == 0:
+        message.channel.send(
+            f"{message.author.mention}, you do not participate in any event.")
+        return True
+    statmsg = ""
+    for data in in_event:
+        challenge = data[0]
+        player = data[1]
+        statmsg += f"\nIn `{challenge.title}` (`{challenge.type.name}`) as "
+        statmsg += f"`{player.['mcname']}`, Status: `{player['status']}`"
+    await message.channel.send(
+        f"{message.author.mention}, you were found in following "
+        + f"events:{statmsg}")
     return False
 
 

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -833,17 +833,18 @@ async def get_help(argstack, botuser, sp):
         description="Manage or attend to skill-leveling events")
     embed.add_field(
         name="Syntax",
-        value=f"`{sp}challenge create` - Create a new challenge event (Admins "
-              + f"only)\n`{sp}challenge join` - Join a challenge event"
-              + f"\n`{sp}challenge list` - List all available events"
-              + f"\n`{sp}challenge accept` - Accept a player entry in an "
-              + "event (Admins only)"
-              + f"\n`{sp}challenge pending` - List players currently waiting "
+        value=f"\n`{sp}chall join` - Join a challenge event"
+              + f"\n`{sp}chall list` - List all available events"
+              + f"\n`{sp}chall pending` - List players currently waiting "
               + "for entry seat approval"
-              + f"\n`{sp}challenge discard` - Discard an event, as if it "
-              + "never happened (Admins only)"
-              + f"\n`{sp}challenge status` - See if you have a seat in an"
+              + f"\n`{sp}chall status` - See if you have a seat in an"
               + "event and watch your status"
-              + f"\n`{sp}challenge results` - See your results in a past "
-              + "event")
+              + f"\n`{sp}chall results` - See your results in a past "
+              + "event"
+              + f"\n\n`{sp}chall create` - Create a new challenge event "
+              + f"(Admins only)"
+              + f"\n`{sp}chall discard` - Discard an event, as if it "
+              + "never happened (Admins only)"
+              + f"\n`{sp}chall accept` - Accept a player entry in an "
+              + "event (Admins only)")
     return [embed]

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -1,8 +1,10 @@
 from asyncio import TimeoutError
 from datetime import datetime
+from discord import Embed
 from src.dcbot import botcommon
 from src.dcbot import client
 from lib.hypixel.hypixelv2 import SBAPIRequest, RequestType
+import uuid
 
 CMD_METADATA = {
     'required_permlevel': botcommon.key_permlevel_user,
@@ -351,10 +353,24 @@ async def _create_challenge(message, arg_stack, botuser):
     if challenge_name is False:
         return False
 
+    challenge_uuid = uuid.uuid4()
+
+    final_challenge = {
+        'uuid': challenge_uuid,
+        'title': challenge_name,
+        'type': challenge_type,
+        'status': 'OPEN',
+        'start_time': start_time.timestamp(),
+        'end_time': end_time.timestamp(),
+        'pay_in': payin_coins,
+        'auto_accept': auto_accept
+    }
+
+    embed = await _get_challenge_preview(final_challenge)
+
     await response_message.edit(
-        content=f"{message.author.mention}, following data gathered right "
-        + f"now:\nType: {challenge_type}, Start Time: {start_time}, End Time: "
-        + f"{end_time}, Pay-In: {payin_coins}, Auto-Accept: {auto_accept}")
+        content=f"{message.author.mention}, confirm this challenge or abort.",
+        embed=embed)
 
 
 async def _join_challenge(message, arg_stack, botuser):

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -655,6 +655,7 @@ async def _join_challenge(message, arg_stack, botuser):
     player_data = {
         'mcname': mcname,
         'mcuuid': mcuuid,
+        'profileid': selected_profile['profile_id'],
         'discordid': message.author.id,
         'state': "ACCEPTED" if selected_challenge.auto_accept else "PENDING"
     }

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -473,7 +473,7 @@ async def _confirm_challenge_creation(
         await response_message.clear_reactions()
         if str(reaction) == "✅":
             await response_message.edit(
-                content=f"{message.author.mention}, created challenge!,",
+                content=f"{message.author.mention}, created challenge!",
                 embed=None)
             return True
         else:

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -822,6 +822,20 @@ async def _tick_challenge(message, arg_stack, botuser):
     await message.channel.send("Called challenge.tick() successfully")
 
 
+async def _update_challenge_embed(message, arg_stack, botuser):
+    if botuser.user_permission_level < botcommon.key_permlevel_moderator:
+        await message.channel.send(
+            f"{message.author.mention}, you have no permission to run this "
+            + "command")
+        return
+    chall_uuid = arg_stack[2]
+    challenge = botcommon.challenge_scheduler.getTask(chall_uuid)
+    if challenge is None:
+        await message.channel.send("Challenge not found!")
+    await message.channel.send("Call challenge.update()")
+    await challenge.update_challenge_embed()
+
+
 @botcommon.requires_perm_level(level=CMD_METADATA['required_permlevel'])
 @botcommon.requires_channel(CMD_METADATA['required_channels'])
 async def invoke(message, arg_stack, botuser):
@@ -852,6 +866,9 @@ async def invoke(message, arg_stack, botuser):
 
         if arg_stack[1].lower() == "tick":
             return await _tick_challenge(message, arg_stack, botuser)
+
+        if arg_stack[1].lower() == "update":
+            return await _update_challenge_embed(message, arg_stack, botuser)
 
     await message.channel.send("Wrong syntax - see `help chall` for usage")
 

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -692,6 +692,13 @@ async def _accept_player(message, arg_stack, botuser):
     return True
 
 
+async def _get_pending_players(message, arg_stack, botuser):
+    # TODO: From all currently tracked challenges that are OPEN or PENDING,
+    #       and are not Auto-Accepting, list all players that currently wait
+    #       for approval. No more action planned, only the player list.
+    return True
+
+
 async def _get_tracked_challenge_by_uuid(
         message, arg_stack, botuser, response_message):
     await response_message.edit(
@@ -739,6 +746,22 @@ async def _discard_challenge(message, arg_stack, botuser):
     return True
 
 
+async def _get_player_status(message, arg_stack, botuser):
+    # TODO: Get all currently tracked challenges that the player is found in
+    # TODO: Show the current status of the player for all challenges
+    return False
+
+
+async def _get_player_results(message, arg_stack, botuser):
+    # TODO: Ask user for challenge UUID
+    # TODO: Find challenge in archived data or return if not found
+    # TODO: When player did not joined this event, insult the user and return
+    # TODO: When player has state "PENDING", "DISQUALIFIED" or "ERRORED",
+    #       Show a message explaining his state and return
+    # TODO: Actually show the result of the player in this challenge
+    return False
+
+
 @botcommon.requires_perm_level(level=CMD_METADATA['required_permlevel'])
 @botcommon.requires_channel(CMD_METADATA['required_channels'])
 async def invoke(message, arg_stack, botuser):
@@ -757,6 +780,15 @@ async def invoke(message, arg_stack, botuser):
 
         if arg_stack[1].lower() == "discard":
             return await _discard_challenge(message, arg_stack, botuser)
+
+        if arg_stack[1].lower() == "pending":
+            return await _get_pending_players(message, arg_stack, botuser)
+
+        if arg_stack[1].lower() == "status":
+            return await _get_player_status(message, arg_stack, botuser)
+
+        if arg_stack[1].lower() == "results":
+            return await _get_player_results(message, arg_stack, botuser)
 
     await message.channel.send("Wrong syntax - see `help chall` for usage")
 

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -669,7 +669,16 @@ async def _join_challenge(message, arg_stack, botuser):
 
 
 async def _list_challenges(message, arg_stack, botuser):
-    # TODO: List available challenges
+    available_challenges = botcommon.challenge_scheduler.getAllTasks()
+    if len(available_challenges) == 0:
+        await message.channel.send(
+            f"{message.author.mention}, there are no tracked events.")
+        return True
+    available_text = f"{message.author.mention}, currently tracked events:"
+    for challenge in available_challenges:
+        available_text += f"\n {challenge.title} (`{challenge.uuid}`) - "
+        available_text += f"`{challenge.type.name}`, `{challenge.status}`"
+    await message.channel.send(available_text)
     return True
 
 

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -127,7 +127,7 @@ async def _get_selected_challenge(
     for index, challenge in enumerate(available_challenges):
         emote = NUMBER_REACTIONS[index]
         chall_title = challenge.title
-        chall_type = challenge.type.name
+        chall_type = challenge.get_type_name()
         available_text += f"\n{emote} `{chall_title}`, {chall_type}"
     await response_message.edit(content=available_text)
     for i in range(len(available_challenges)):
@@ -678,7 +678,8 @@ async def _list_challenges(message, arg_stack, botuser):
     available_text = f"{message.author.mention}, currently tracked events:"
     for challenge in available_challenges:
         available_text += f"\n {challenge.title} (`{challenge.uuid}`) - "
-        available_text += f"`{challenge.type.name}`, `{challenge.status}`"
+        available_text += f"`{challenge.get_type_name()}`, "
+        available_text += f"`{challenge.status}`"
     await message.channel.send(available_text)
     return True
 
@@ -779,8 +780,8 @@ async def _get_player_status(message, arg_stack, botuser):
     for data in in_event:
         challenge = data[0]
         player = data[1]
-        statmsg += f"\nIn `{challenge.title}` (`{challenge.type.name}`) as "
-        statmsg += f"`{player['mcname']}`, Status: `{player['state']}`"
+        statmsg += f"\nIn `{challenge.title}` (`{challenge.get_type_name()}`) "
+        statmsg += f"as `{player['mcname']}`, Status: `{player['state']}`"
     await message.channel.send(
         f"{message.author.mention}, you were found in following "
         + f"events:{statmsg}")

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -20,12 +20,14 @@ async def _get_available_challenges(
     all_tracked_challenges = botcommon.challenge_scheduler.getAllTasks()
     open_challenges = []
     for challenge in all_tracked_challenges:
-        if challenge.status == botcommon.ChallengeStatus.OPEN:
+        if challenge.status == botcommon.ChallengeStatus.OPEN and \
+                challenge.get_player(message.author.id) is None:
             open_challenges.append(challenge)
     if len(open_challenges) == 0:
         await response_message.edit(
             content=f"{message.author.mention}, there are no open challenges "
-            + "you can currently join.")
+            + "you can currently join. See `chall status` if you are "
+            + "currently participating in a challenge")
         return False
     return open_challenges
 

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -490,6 +490,13 @@ async def _confirm_challenge_creation(
 
 
 async def _create_challenge(message, arg_stack, botuser):
+
+    if botuser.user_permission_level < botcommon.key_permlevel_moderator:
+        await message.channel.send(
+            f"{message.author.mention}, you have no permission to run this "
+            + "command")
+        return
+
     response_message = await message.channel.send(
         f"{message.author.mention}, creating...")
 
@@ -801,6 +808,11 @@ async def _get_player_results(message, arg_stack, botuser):
 
 
 async def _tick_challenge(message, arg_stack, botuser):
+    if botuser.user_permission_level < botcommon.key_permlevel_moderator:
+        await message.channel.send(
+            f"{message.author.mention}, you have no permission to run this "
+            + "command")
+        return
     chall_uuid = arg_stack[2]
     challenge = botcommon.challenge_scheduler.getTask(chall_uuid)
     if challenge is None:

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -779,7 +779,7 @@ async def _get_player_status(message, arg_stack, botuser):
         challenge = data[0]
         player = data[1]
         statmsg += f"\nIn `{challenge.title}` (`{challenge.type.name}`) as "
-        statmsg += f"`{player.['mcname']}`, Status: `{player['status']}`"
+        statmsg += f"`{player['mcname']}`, Status: `{player['status']}`"
     await message.channel.send(
         f"{message.author.mention}, you were found in following "
         + f"events:{statmsg}")

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -314,7 +314,8 @@ async def _get_channel_to_announce(
         else:
             entered_channel = announcemessage.content
             await announcemessage.delete()
-            channel = await botcommon.get_channel_by_id_or_ping(entered_channel)
+            channel = await botcommon.get_channel_by_id_or_ping(
+                entered_channel)
             if channel is None:
                 await response_message.edit(
                     content=f"{message.author.mention}, please enter a valid "
@@ -476,7 +477,7 @@ async def _create_challenge(message, arg_stack, botuser):
 
     final_challenge.announcement_message_id = announcement_message.id
 
-    botcommon.open_challenges[final_challenge.uuid] = final_challenge
+    botcommon.challenge_scheduler.addTask(final_challenge)
 
 
 async def _join_challenge(message, arg_stack, botuser):

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -1,5 +1,5 @@
 from asyncio import TimeoutError
-from datetime import datetime
+from datetime import datetime, timedelta
 from discord import Embed
 from src.dcbot import botcommon
 from src.dcbot import client
@@ -292,6 +292,14 @@ async def _get_challenge_name(message, arg_stack, botuser, response_message):
     return chosen_name
 
 
+def _determine_entries_closing_time(start_time, auto_accept):
+
+    if auto_accept:
+        return start_time + timedelta(minutes=-15)
+    else:
+        return start_time + timedelta(hours=-1)
+
+
 async def _get_challenge_preview(challenge):
     embed = Embed(
         title=challenge['title'],
@@ -303,6 +311,9 @@ async def _get_challenge_preview(challenge):
     embed.add_field(
         name="Status",
         value=challenge['status'])
+    embed.add_field(
+        name="Entries close time",
+        value=datetime.fromtimestamp(challenge['entries_close_time']))
     embed.add_field(
         name="Start",
         value=datetime.fromtimestamp(challenge['start_time']))
@@ -354,6 +365,8 @@ async def _create_challenge(message, arg_stack, botuser):
         return False
 
     challenge_uuid = uuid.uuid4()
+    entries_close_time = _determine_entries_closing_time(
+        start_time, auto_accept)
 
     final_challenge = {
         'uuid': challenge_uuid,
@@ -361,6 +374,7 @@ async def _create_challenge(message, arg_stack, botuser):
         'type': challenge_type,
         'status': 'OPEN',
         'start_time': start_time.timestamp(),
+        'entries_close_time': entries_close_time.timestamp(),
         'end_time': end_time.timestamp(),
         'pay_in': payin_coins,
         'auto_accept': auto_accept

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -738,7 +738,6 @@ async def _discard_challenge(message, arg_stack, botuser):
         message, arg_stack, botuser, response_message)
     if selected_challenge is False:
         return False
-    botcommon.challenge_scheduler.removeTask(selected_challenge)
     await selected_challenge.discard()
     await response_message.edit(
         content=f"{message.author.mention}, challenge "

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -22,8 +22,9 @@ async def _get_available_profiles(
         return False
     uuid = uuid['id']
     profilesrequest = SBAPIRequest(RequestType.PROFILES, (uuid,))
-    profiles = await botcommon.hypixel_api.request(profilesrequest, 5)
+    profiles = await botcommon.hypixel_api.request(profilesrequest, 10)
     if 'dd_error' in profiles:
+        print(profiles)
         await response_message.edit(
             content=f"{message.author.mention}, there was an error while "
             + "getting your skyblock profiles. Try again later.")

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -72,7 +72,6 @@ async def _get_available_profiles(
     profilesrequest = SBAPIRequest(RequestType.PROFILES, (mcuuid,))
     profiles = await botcommon.hypixel_api.request(profilesrequest, 10)
     if 'dd_error' in profiles:
-        print(profiles)
         await response_message.edit(
             content=f"{message.author.mention}, there was an error while "
             + "getting your skyblock profiles. Try again later.")
@@ -121,7 +120,6 @@ async def _get_selected_profile(
 
 async def _get_selected_challenge(
         message, arg_stack, botuser, response_message, available_challenges):
-    print(available_challenges)
     if len(available_challenges) == 1:
         return available_challenges[0]
     available_text = f"{message.author.mention}, please select the " \

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -804,7 +804,11 @@ async def get_help(argstack, botuser, sp):
               + f"\n`{sp}challenge accept` - Accept a player entry in an "
               + "event (Admins only)"
               + f"\n`{sp}challenge pending` - List players currently waiting "
-              + "for approval by an admin with their entry seat"
-              + f"\n`{sp}challenge discard` - Discard an event, untrack "
-              + "players and archive the data (Admins only)")
+              + "for entry seat approval"
+              + f"\n`{sp}challenge discard` - Discard an event, as if it "
+              + "never happened (Admins only)"
+              + f"\n`{sp}challenge status` - See if you have a seat in an"
+              + "event and watch your status"
+              + f"\n`{sp}challenge results` - See your results in a past "
+              + "event")
     return [embed]

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -684,3 +684,21 @@ async def invoke(message, arg_stack, botuser):
             return await _discard_challenge(message, arg_stack, botuser)
 
     await message.channel.send("Wrong syntax - see `help chall` for usage")
+
+
+async def get_help(argstack, botuser, sp):
+    embed = Embed(
+        title="Hypixel Skyblock skill-leveling events",
+        description="Manage or attend to skill-leveling events")
+    embed.add_field(
+        name="Syntax",
+        value=f"`{sp}challenge create` - Create a new challenge event (Admins "
+              + f"only)\n`{sp}challenge join` - Join a challenge event"
+              + f"\n`{sp}challenge list` - List all available events"
+              + f"\n`{sp}challenge accept` - Accept a player entry in an "
+              + "event (Admins only)"
+              + f"\n`{sp}challenge pending` - List players currently waiting "
+              + "for approval by an admin with their entry seat"
+              + f"\n`{sp}challenge discard` - Discard an event, untrack "
+              + "players and archive the data (Admins only)")
+    return [embed]

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -796,6 +796,16 @@ async def _get_player_results(message, arg_stack, botuser):
     return False
 
 
+async def _tick_challenge(message, arg_stack, botuser):
+    chall_uuid = arg_stack[2]
+    challenge = botcommon.challenge_scheduler.getTask(chall_uuid)
+    if challenge is None:
+        await message.channel.send("Challenge not found!")
+    await message.channel.send("Call challenge.tick()")
+    challenge.tick()
+    await message.channel.send("Called challenge.tick() successfully")
+
+
 @botcommon.requires_perm_level(level=CMD_METADATA['required_permlevel'])
 @botcommon.requires_channel(CMD_METADATA['required_channels'])
 async def invoke(message, arg_stack, botuser):
@@ -823,6 +833,9 @@ async def invoke(message, arg_stack, botuser):
 
         if arg_stack[1].lower() == "results":
             return await _get_player_results(message, arg_stack, botuser)
+
+        if arg_stack[1].lower() == "tick":
+            return await _tick_challenge(message, arg_stack, botuser)
 
     await message.channel.send("Wrong syntax - see `help chall` for usage")
 

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -407,9 +407,9 @@ async def _get_channel_to_announce(
 def _determine_entries_closing_time(start_time, auto_accept):
 
     if auto_accept:
-        return start_time + timedelta(minutes=-15)
+        return start_time + timedelta(minutes=-2)
     else:
-        return start_time + timedelta(hours=-1)
+        return start_time + timedelta(minutes=-15)
 
 
 async def _get_challenge_preview(challenge, announcement_channel):

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -1,0 +1,72 @@
+from src.dcbot import botcommon
+from src.dcbot import client
+import asyncio
+from src.translation import transget
+from lib.hypixel.hypixelv2 import SBAPIRequest, RequestType
+
+CMD_METADATA = {
+    'required_permlevel': botcommon.key_permlevel_user,
+    'required_channels': [botcommon.key_bot_userchannel,
+                          botcommon.key_bot_adminchannel]}
+
+NUMBER_REACTIONS = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣', ]
+
+
+async def _get_available_profiles(message, arg_stack, botuser):
+    uuidrequest = SBAPIRequest(RequestType.GETUUID, (arg_stack[1],))
+    uuid = await botcommon.hypixel_api.request(uuidrequest, 5)
+    if 'dd_error' in uuid:
+        await message.channel.send(f"{message.author.mention}, this player does not exist.")
+        return False
+    uuid = uuid['id']
+    profilesrequest = SBAPIRequest(RequestType.PROFILES, (uuid,))
+    profiles = await botcommon.hypixel_api.request(profilesrequest, 5)
+    if 'dd_error' in profiles:
+        await message.channel.send(f"{message.author.mention}, there was an error while getting your skyblock profiles. Try again later.")
+        return False
+    if profiles['profiles'] == None:
+        await message.channel.send(f"{message.author.mention}, this player does not have a skyblock profile.")
+        return False
+    return list(profiles['profiles'])
+
+
+async def _get_selected_profile(message, arg_stack, botuser, available_profiles):
+    if len(available_profiles) == 1:
+        return available_profiles[0]
+    available_text = f"{message.author.mention}, please select your profile:"
+    for index, profile in enumerate(available_profiles):
+        emote = NUMBER_REACTIONS[index]
+        pname = profile['cute_name']
+        available_text += f"\n{emote} {pname}"
+    pselector = await message.channel.send(available_text)
+    for i in range(len(available_profiles)):
+        await pselector.add_reaction(NUMBER_REACTIONS[i])
+
+    def pselect_check(reaction, user):
+        return user.id == message.author.id and reaction.message.id == pselector.id and str(reaction) in NUMBER_REACTIONS[:len(available_profiles)]
+
+    try:
+        reaction, reactionuser = await client.wait_for('reaction_add', check=pselect_check, timeout=30.0)
+    except asyncio.TimeoutError:
+        await pselector.delete()
+        await message.channel.send(f"{message.author.mention}, session closed!")
+        return False
+    else:
+        selected_profile = available_profiles[NUMBER_REACTIONS.index(str(reaction))]
+        await pselector.delete()
+        return selected_profile
+    return False
+
+
+@botcommon.requires_perm_level(level=CMD_METADATA['required_permlevel'])
+@botcommon.requires_channel(CMD_METADATA['required_channels'])
+async def invoke(message, arg_stack, botuser):
+    if len(arg_stack) >= 2:
+        available_profiles = await _get_available_profiles(message, arg_stack, botuser)
+        if available_profiles is False:
+            return False
+        selected_profile = await _get_selected_profile(message, arg_stack, botuser, available_profiles)
+        if selected_profile is False:
+            return False
+
+        await message.channel.send(f"{message.author.mention}, selected profile: {selected_profile['cute_name']}")

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -55,9 +55,9 @@ async def _get_minecraft_name(message, arg_stack, botuser, response_message):
             await response_message.edit(
                 content=f"{message.author.mention}, fetching...")
             uuidrequest = SBAPIRequest(RequestType.GETUUID, (entered_name,))
-    uuid = await botcommon.hypixel_api.request(uuidrequest, 5)
-    if 'dd_error' in uuid:
-        await response_message.edit(
+            uuid = await botcommon.hypixel_api.request(uuidrequest, 5)
+            if 'dd_error' in uuid:
+                await response_message.edit(
                     content=f"{message.author.mention}, the user "
                     + f"'{entered_name}' does not exist. Please enter your "
                     + "real minecraft username!")
@@ -554,6 +554,19 @@ async def _join_challenge(message, arg_stack, botuser):
     return True
 
 
+async def _list_challenges(message, arg_stack, botuser):
+    # TODO: List available challenges
+    return True
+
+
+async def _accept_player(message, arg_stack, botuser):
+    # TODO: Check if author is admin/moderator
+    # TODO: Ask Author for mc-name/mc-uuid/discord-ping/discord-id of user
+    # TODO: Check if this user is currently trying to attend to a challenge
+    # TODO: If multiple challenges are available, let Author choose which
+    # TODO: Update this player and accept him in the challenge
+    return True
+
 
 async def _get_tracked_challenge_by_uuid(
         message, arg_stack, botuser, response_message):
@@ -612,6 +625,11 @@ async def invoke(message, arg_stack, botuser):
         if arg_stack[1].lower() == "join":
             return await _join_challenge(message, arg_stack, botuser)
 
+        if arg_stack[1].lower() == "list":
+            return await _list_challenges(message, arg_stack, botuser)
+
+        if arg_stack[1].lower() == "accept":
+            return await _accept_player(message, arg_stack, botuser)
 
         if arg_stack[1].lower() == "discard":
             return await _discard_challenge(message, arg_stack, botuser)

--- a/src/dcbot/commands/chall.py
+++ b/src/dcbot/commands/chall.py
@@ -693,9 +693,27 @@ async def _accept_player(message, arg_stack, botuser):
 
 
 async def _get_pending_players(message, arg_stack, botuser):
-    # TODO: From all currently tracked challenges that are OPEN or PENDING,
-    #       and are not Auto-Accepting, list all players that currently wait
-    #       for approval. No more action planned, only the player list.
+    pending_players = []
+    for challenge in botcommon.challenge_scheduler.getAllTasks():
+        if challenge.status is botcommon.ChallengeStatus.OPEN or \
+                challenge.status is botcommon.ChallengeStatus.PENDING:
+            for player in challenge.get_pending_players():
+                pending_players.append((player, challenge))
+    if len(pending_players) == 0:
+        await message.channel.send(
+            f"{message.author.mention}, there are no pending players in any "
+            + "currently tracked event.")
+        return True
+    playertext = ""
+    for player in pending_players:
+        mcname = player[0]['mcname']
+        challtitle = player[1].title
+        challuuid = player[1].uuid
+        playertext += f"\n`{mcname}` in `{challtitle}` (`{challuuid}`)"
+
+    await message.channel.send(
+        f"{message.author.mention}, currently pending players:{playertext}")
+
     return True
 
 

--- a/src/dcbot/commands/help.py
+++ b/src/dcbot/commands/help.py
@@ -10,7 +10,7 @@ CMD_METADATA = {
 
 
 async def get_help(arg_stack, botuser, shortprefix):
-    return[]
+    return []
 
 
 async def _do_general_help(message, arg_stack, botuser):
@@ -30,6 +30,7 @@ async def _do_general_help(message, arg_stack, botuser):
                 botuser.user_pref_lang) + "\n"
     helpmsg += "```"
     await message.channel.send(helpmsg)
+    return True
 
 
 async def _do_specific_help(message, arg_stack, botuser):
@@ -41,29 +42,35 @@ async def _do_specific_help(message, arg_stack, botuser):
     except ModuleNotFoundError:
         # TODO: Translate this
         await message.channel.send("Command not found")
+        return False
     else:
         try:
             if botuser.user_permission_level >= \
                     cmdimport.CMD_METADATA['required_permlevel']:
                 cmdhelp = await cmdimport.get_help(
                     arg_stack, botuser, shortprefix)
-                for embed in cmdhelp:
-                    await message.channel.send(embed=embed)
                 if cmdhelp is None or cmdhelp == []:
                     await message.channel.send(
                         "This command does not implement help functions.")
+                    return False
+                for embed in cmdhelp:
+                    await message.channel.send(embed=embed)
             else:
                 await message.channel.send(
                     "You have no permission to get help for this command.")
+                return True
         except Exception:
             await message.channel.send(
                 "This command has no function to print help.")
+            return False
+        return True
+    return False
 
 
 @botcommon.requires_perm_level(level=CMD_METADATA['required_permlevel'])
 @botcommon.requires_channel(CMD_METADATA['required_channels'])
 async def invoke(message, arg_stack, botuser):
     if len(arg_stack) == 1:
-        await _do_general_help(message, arg_stack, botuser)
+        return await _do_general_help(message, arg_stack, botuser)
     else:
-        await _do_specific_help(message, arg_stack, botuser)
+        return await _do_specific_help(message, arg_stack, botuser)

--- a/src/dcbot/commands/stop.py
+++ b/src/dcbot/commands/stop.py
@@ -21,6 +21,7 @@ async def invoke(message, arg_stack, botuser):
     botcommon.hypixel_api.join()
 
     print("Stopping Challenge Scheduler...")
+    botcommon.challenge_scheduler.save_all_tracked()
     botcommon.challenge_scheduler.stop()
     botcommon.challenge_scheduler.join()
 

--- a/src/dcbot/commands/stop.py
+++ b/src/dcbot/commands/stop.py
@@ -12,12 +12,23 @@ CMD_METADATA = {
 @botcommon.requires_perm_level(level=CMD_METADATA['required_permlevel'])
 @botcommon.requires_channel(CMD_METADATA['required_channels'])
 async def invoke(message, arg_stack, botuser):
-    botcommon.is_bot_stopping = True
-    botcommon.hypixel_api.input.put("#STOP#")
 
+    print("Bot stops now because admin command $stop invoked")
+    botcommon.is_bot_stopping = True
+
+    print("Stopping Hypixel API...")
+    botcommon.hypixel_api.stop()
+    botcommon.hypixel_api.join()
+
+    print("Stopping Challenge Scheduler")
+    botcommon.challenge_scheduler.stop()
+    botcommon.challenge_scheduler.join()
+
+    print("Closing and deleting active dynamic voice channels")
     for vchannel_obj in botcommon.bot_voice_channels:
         await voicecommon.delete_channel(vchannel_obj)
 
+    print("Log close action to log channel")
     embed = Embed(
         title="Bot shuts down",
         description="Due to an admin command the bot shuts down now.",
@@ -28,6 +39,7 @@ async def invoke(message, arg_stack, botuser):
     embed.set_footer(text=footertext)
     await trytolog(message, arg_stack, botuser, embed)
 
-    print("Gracefully shut down bot due to admin command")
+    print("Logout the bot client and return from discordpy")
     await client.logout()
+    print("Bot stopped successfully!")
     return True

--- a/src/dcbot/commands/stop.py
+++ b/src/dcbot/commands/stop.py
@@ -13,6 +13,7 @@ CMD_METADATA = {
 @botcommon.requires_channel(CMD_METADATA['required_channels'])
 async def invoke(message, arg_stack, botuser):
     botcommon.is_bot_stopping = True
+    botcommon.hypixel_api.input.put("#STOP#")
 
     for vchannel_obj in botcommon.bot_voice_channels:
         await voicecommon.delete_channel(vchannel_obj)

--- a/src/dcbot/commands/stop.py
+++ b/src/dcbot/commands/stop.py
@@ -20,15 +20,15 @@ async def invoke(message, arg_stack, botuser):
     botcommon.hypixel_api.stop()
     botcommon.hypixel_api.join()
 
-    print("Stopping Challenge Scheduler")
+    print("Stopping Challenge Scheduler...")
     botcommon.challenge_scheduler.stop()
     botcommon.challenge_scheduler.join()
 
-    print("Closing and deleting active dynamic voice channels")
+    print("Closing and deleting active dynamic voice channels...")
     for vchannel_obj in botcommon.bot_voice_channels:
         await voicecommon.delete_channel(vchannel_obj)
 
-    print("Log close action to log channel")
+    print("Log close action to log channel...")
     embed = Embed(
         title="Bot shuts down",
         description="Due to an admin command the bot shuts down now.",
@@ -39,7 +39,7 @@ async def invoke(message, arg_stack, botuser):
     embed.set_footer(text=footertext)
     await trytolog(message, arg_stack, botuser, embed)
 
-    print("Logout the bot client and return from discordpy")
+    print("Logout the bot client and return from discordpy...")
     await client.logout()
     print("Bot stopped successfully!")
     return True

--- a/src/dcbot/commands/stop.py
+++ b/src/dcbot/commands/stop.py
@@ -20,8 +20,9 @@ async def invoke(message, arg_stack, botuser):
     botcommon.hypixel_api.stop()
     botcommon.hypixel_api.join()
 
-    print("Stopping Challenge Scheduler...")
+    print("Save currently tracked challenges to disk")
     botcommon.challenge_scheduler.save_all_tracked()
+    print("Stopping Challenge Scheduler...")
     botcommon.challenge_scheduler.stop()
     botcommon.challenge_scheduler.join()
 

--- a/src/dcbot/events/on_ready.py
+++ b/src/dcbot/events/on_ready.py
@@ -15,11 +15,13 @@ async def on_ready():
     print("Initializing the bot...")
     print(f"Setting main guild to {str(client.guilds[0])}")
     botcommon.main_guild = client.guilds[0]
+
     # Place all commands in a register used for the help command
     print("Getting all enabled commands...")
     for importer, modname, ispkg in pkgutil.iter_modules(commands.__path__):
         if not str(modname).startswith('_'):
             botcommon.registered_bot_commands.append(modname)
+
     # Place all message processors in a register to call everyone of them
     # on every message ever sent
     print("Getting all enabled message processors...")
@@ -27,14 +29,21 @@ async def on_ready():
             messageprocessors.__path__):
         if not str(modname).startswith('_'):
             botcommon.registered_message_processors.append(modname)
+
     print("Starting Hypixel API...")
     botcommon.hypixel_api = hypixelv2.SkyblockAPI(
         os.getenv('DD_HYPIXEL_API_KEY', ''))
     botcommon.hypixel_api.start()
-    print("Starting Challenge Event scheduler")
+
+    print("Starting Challenge Event scheduler...")
     botcommon.challenge_scheduler = botcommon.ChallengeScheduler()
     botcommon.challenge_scheduler.start()
+
+    print("Load previously tracked challenge events into the scheduler...")
     botcommon.challenge_scheduler.load_all_tracked()
+    for challenge in botcommon.challenge_scheduler.getAllTasks():
+        await challenge.update_challenge_embed()
+
     # Log the ready-state of the bot in the console.
     message = transget("dcbot.readymessage").format(
         client=client.user)

--- a/src/dcbot/events/on_ready.py
+++ b/src/dcbot/events/on_ready.py
@@ -10,6 +10,12 @@ from lib.hypixel import hypixelv2
 
 @client.event
 async def on_ready():
+
+    if not botcommon.is_initial_start:
+        print("Bot reconnected to discord after connection loss")
+        return
+    botcommon.is_initial_start = False
+
     # Setting the first guild (which is the only guild per definition) to a
     # commonly accessible variable
     print("Initializing the bot...")

--- a/src/dcbot/events/on_ready.py
+++ b/src/dcbot/events/on_ready.py
@@ -1,9 +1,11 @@
+import os
 import pkgutil
 from src.dcbot import client
 from src.dcbot import botcommon
 from src.dcbot import messageprocessors
 from src.dcbot import commands
 from src.translation import transget
+from lib.hypixel import hypixelv2
 
 
 @client.event
@@ -21,6 +23,9 @@ async def on_ready():
             messageprocessors.__path__):
         if not str(modname).startswith('_'):
             botcommon.registered_message_processors.append(modname)
+
+    botcommon.hypixel_api = hypixelv2.SkyblockAPI(os.getenv('DD_HYPIXEL_API_KEY', ''))
+    botcommon.hypixel_api.start()
     # Log the ready-state of the bot in the console.
     message = transget("dcbot.readymessage").format(
         client=client.user)

--- a/src/dcbot/events/on_ready.py
+++ b/src/dcbot/events/on_ready.py
@@ -39,7 +39,7 @@ async def on_ready():
     botcommon.challenge_scheduler = botcommon.ChallengeScheduler()
     botcommon.challenge_scheduler.start()
 
-    print("Load previously tracked challenge events into the scheduler...")
+    print("Load previously tracked challenge events")
     botcommon.challenge_scheduler.load_all_tracked()
 
     # Log the ready-state of the bot in the console.

--- a/src/dcbot/events/on_ready.py
+++ b/src/dcbot/events/on_ready.py
@@ -12,23 +12,29 @@ from lib.hypixel import hypixelv2
 async def on_ready():
     # Setting the first guild (which is the only guild per definition) to a
     # commonly accessible variable
+    print("Initializing the bot...")
+    print(f"Setting main guild to {str(client.guilds[0])}")
     botcommon.main_guild = client.guilds[0]
     # Place all commands in a register used for the help command
+    print("Getting all enabled commands...")
     for importer, modname, ispkg in pkgutil.iter_modules(commands.__path__):
         if not str(modname).startswith('_'):
             botcommon.registered_bot_commands.append(modname)
     # Place all message processors in a register to call everyone of them
     # on every message ever sent
+    print("Getting all enabled message processors...")
     for importer, modname, ispkg in pkgutil.iter_modules(
             messageprocessors.__path__):
         if not str(modname).startswith('_'):
             botcommon.registered_message_processors.append(modname)
-
+    print("Starting Hypixel API...")
     botcommon.hypixel_api = hypixelv2.SkyblockAPI(
         os.getenv('DD_HYPIXEL_API_KEY', ''))
     botcommon.hypixel_api.start()
+    print("Starting Challenge Event scheduler")
     botcommon.challenge_scheduler = botcommon.ChallengeScheduler()
     botcommon.challenge_scheduler.start()
+    botcommon.challenge_scheduler.load_all_tracked()
     # Log the ready-state of the bot in the console.
     message = transget("dcbot.readymessage").format(
         client=client.user)

--- a/src/dcbot/events/on_ready.py
+++ b/src/dcbot/events/on_ready.py
@@ -41,8 +41,6 @@ async def on_ready():
 
     print("Load previously tracked challenge events into the scheduler...")
     botcommon.challenge_scheduler.load_all_tracked()
-    for challenge in botcommon.challenge_scheduler.getAllTasks():
-        await challenge.update_challenge_embed()
 
     # Log the ready-state of the bot in the console.
     message = transget("dcbot.readymessage").format(

--- a/src/dcbot/events/on_ready.py
+++ b/src/dcbot/events/on_ready.py
@@ -27,6 +27,8 @@ async def on_ready():
     botcommon.hypixel_api = hypixelv2.SkyblockAPI(
         os.getenv('DD_HYPIXEL_API_KEY', ''))
     botcommon.hypixel_api.start()
+    botcommon.challenge_scheduler = botcommon.ChallengeScheduler()
+    botcommon.challenge_scheduler.start()
     # Log the ready-state of the bot in the console.
     message = transget("dcbot.readymessage").format(
         client=client.user)

--- a/src/dcbot/events/on_ready.py
+++ b/src/dcbot/events/on_ready.py
@@ -24,7 +24,8 @@ async def on_ready():
         if not str(modname).startswith('_'):
             botcommon.registered_message_processors.append(modname)
 
-    botcommon.hypixel_api = hypixelv2.SkyblockAPI(os.getenv('DD_HYPIXEL_API_KEY', ''))
+    botcommon.hypixel_api = hypixelv2.SkyblockAPI(
+        os.getenv('DD_HYPIXEL_API_KEY', ''))
     botcommon.hypixel_api.start()
     # Log the ready-state of the bot in the console.
     message = transget("dcbot.readymessage").format(


### PR DESCRIPTION
This integrates the system for skill leveling challenges (and slayer, and possibly collections), closes #19

Todo until mergable:

- [x] Scheduler system
    - [x] Add a challenge to the scheduler
    - [x] Determine if challenge needs to update its state and gather data - "Tick"
    - [x] Update (advance/increment) challenge state on tick
    - [x] Update announcement message on tick
    - [x] Gather player stats on tick if needed
    - [x] Create leaderboard on tick if needed (Data shows: Leaderboard in embed can only show up to 15 players)
- [x] Ability for admin/moderator to create challenges
    - [x] Set basic info (Type, start time, end time, name, pay-in, auto-accept, etc.)
    - [x] Create an announcement message, informing players about the challenge event
    - [x] Do this permission-based, so not everyone can create a challenge
- [x] Players can join the challenge
    - [x] Check if there are challenges the player can join (Is there a OPEN challenge the player is **not yet participating in**?)
        - [x] **Not yet participating** check is not implemented until stress test (requires finished scheduler system & accepting players)
    - [x] Let the player choose with what profile they want to join
    - [x] Let the player choose what challenge they want to join
    - [x] Show player a preview of their entry and let them confirm
    - [x] Update the challenge object (Needed data: Discord ID, MC UUID, Profile UUID)
    - [x] Automatically confirm entry when Auto-Accept is on
        - [x] Update the announcement embed with new participants-count 
- [ ] Admins/Moderators can confirm the entry of a player when Auto-Accept is off
    - [x] List all players currently participating, filter by acception-state
    - [ ] Accept a player
        - [ ] Update the announcement embed with new participants-count
        - [ ] Update player info in challenge object, setting its state to CONFIRMED
- [x] Event hooks
    - [x] On Bot stop, save all currently tracked challenge events
    - [x] On Bot start, load all challenge events found in ./data that need to be tracked again
    - [x] On Challenge status changing to DISCARD or ENDED, save this challenge into the challenge archive
        - [x] Un-Schedule the challenge
 
## Testing this new feature
I did some manual testing (semi-automated unit tests, no integration tests)
Whole feature integration can only effectively being tested with live data. As Hypixel offers no fake-data API, this will ultimately needs testing in production. Booo!

## Current Flaws

- [x] When Bot reconnects without graceful stop before (Internet connection down, timeout, crash), the bot loses tracking of current events (THE CHALLENGE EVENT GETS DELETED!)
    - [x] Add a global variable "INITIAL_START" set to True, and inside on_read set it to False.
    - [x] Only reinstanciate hypixel_api and challenge_scheduler, when INITIAL_START is True.
    - [x] If tracked_challenges.json is not found in data/, do not reload challenges in on_ready()

## Other features
- Dynamic Bot response system
    - Bot should only respond with exactly one message to each command invoke. This implies a technique that passes a message object between called coroutines inside a command. This Release introduces such a system.
- On stopping the bot, the current global bot state can be saved as a snapshot and loaded on next bot start, so no data loss.
    - This will come in handy on following updates that revamp the current (beta) dynamic voice channels