### PR TITLE
Small fixes for boosted 1Heads

### DIFF
--- a/resources/translations/source.json
+++ b/resources/translations/source.json
@@ -296,48 +296,48 @@
     "de": "Du kannst dich nicht selbst aus dem Channel kicken."
   },
   "command.voice.help.toggle.syntax": {
-    "en": "`voice toggle`",
-    "de": "`voice toggle`"
+    "en": "voice toggle",
+    "de": "voice toggle"
   },
   "command.voice.help.toggle.description": {
     "en": "Toggle the channel visibility between public and private. **This edits the channel!**",
     "de": "Wechselt die Sichtbarkeit des Voicechannels zwischen privat und öffentlich. **Das editiert den Channel!**"
   },
   "command.voice.help.name.syntax": {
-    "en": "`voice name <new-name>`",
-    "de": "`voice name <neuer-name>`"
+    "en": "voice name <new-name>",
+    "de": "voice name <neuer-name>"
   },
   "command.voice.help.name.description": {
     "en": "Set a custom name for the channel. Names are limited to 20 alphanumeric characters. **This edits the channel!**",
     "de": "Ändert den Namen deines Channels. Maximal 20 alphanumerische Zeichen. **Das editiert den Channel!**"
   },
   "command.voice.help.transfer.syntax": {
-    "en": "`voice transfer <user-ping|user-id>`",
-    "de": "`voice transfer <user-ping|user-id>`"
+    "en": "voice transfer <user-ping|user-id>",
+    "de": "voice transfer <user-ping|user-id>"
   },
   "command.voice.help.transfer.description": {
     "en": "Transfer the channel ownership to another user. This user must be currently connected to the voice channel.",
     "de": "Überträgt den Channelbesitz an einen anderen User. Dieser User muss dazu im Voicechannel verbunden sein."
   },
   "command.voice.help.invite.syntax": {
-    "en": "`voice invite <user-ping|user-id>`",
-    "de": "`voice invite <user-ping|user-id>`"
+    "en": "voice invite <user-ping|user-id>",
+    "de": "voice invite <user-ping|user-id>"
   },
   "command.voice.help.invite.description": {
     "en": "**Only private channels**: Make this channel visible for a specific user. You can use this command in every text channel on this server.",
     "de": "**Nur in privaten Channeln verfügbar**: Lädt einen User in diesen Channel ein und macht diesen damit für ihn sichtbar. Dieser Command kann in allen Textchanneln auf dem Server verwendet werden."
   },
   "command.voice.help.kick.syntax": {
-    "en": "`voice kick <user-ping|user-id>`",
-    "de": "`voice kick <user-ping|user-id>`"
+    "en": "voice kick <user-ping|user-id>",
+    "de": "voice kick <user-ping|user-id>"
   },
   "command.voice.help.kick.description": {
     "en": "**Only private channels**: Kick a user and make this channel invisible for him again.",
     "de": "**Nur in privaten Channeln verfügbar**: Kickt einen User aus diesem Channel und macht diesen für ihn wieder unsichtbar."
   },
   "command.voice.help.close.syntax": {
-    "en": "`voice close`",
-    "de": "`voice close`"
+    "en": "voice close",
+    "de": "voice close"
   },
   "command.voice.help.close.description": {
     "en": "Manually close this channel. (It gets closed automatically if everyone leaves)",

--- a/src/dcbot/commands/stop.py
+++ b/src/dcbot/commands/stop.py
@@ -58,7 +58,7 @@ async def logout_client():
 async def invoke(message, arg_stack, botuser):
 
     await bare_stop()
-    await log_to_channel(message)
+    await log_to_channel(message, arg_stack, botuser)
     await logout_client()
 
     return True

--- a/src/dcbot/events/on_voice_state_update.py
+++ b/src/dcbot/events/on_voice_state_update.py
@@ -45,7 +45,8 @@ async def on_voice_state_update(member, before, after):
         await voicecommon.send_init_help(channel_obj, botuser)
 
     # When old channel is dynamic
-    if voicecommon.get_channel_obj_by_channel(before.channel) is not None:
+    if voicecommon.get_channel_obj_by_channel(before.channel) is not None \
+            and after.channel != before.channel:
         channel_obj = voicecommon.get_channel_obj_by_channel(before.channel)
         if channel_obj['type'] == "public":
             # Only take away role when channel is public.
@@ -58,7 +59,8 @@ async def on_voice_state_update(member, before, after):
             await voicecommon.delete_channel(channel_obj)
 
     # Check if new channel is dynamic
-    if voicecommon.get_channel_obj_by_channel(after.channel) is not None:
+    if voicecommon.get_channel_obj_by_channel(after.channel) is not None \
+            and before.channel != after.channel:
         channel_obj = voicecommon.get_channel_obj_by_channel(after.channel)
         if channel_obj['type'] == "public":
             # Only give role when channel is public.

--- a/src/dcbot/events/voice_events/voicecommon.py
+++ b/src/dcbot/events/voice_events/voicecommon.py
@@ -1,4 +1,5 @@
 from src.dcbot import botcommon
+from src.database import dbcommon
 from src.dcbot import client
 from src.translation import transget
 from discord import PermissionOverwrite
@@ -41,6 +42,7 @@ async def delete_channel(channel_obj):
 
 
 async def send_init_help(channel_obj, botuser):
+    shortprefix = dbcommon.get_bot_setting(botcommon.key_bot_prefix, "$")
     tc = client.get_channel(channel_obj['textchannel'])
     embed = Embed(
         title=transget(
@@ -51,44 +53,44 @@ async def send_init_help(channel_obj, botuser):
             botuser.user_pref_lang),
         color=botcommon.key_color_info)
     embed.add_field(
-        name=transget(
+        name='`' + shortprefix + transget(
             "command.voice.help.toggle.syntax",
-            botuser.user_pref_lang),
+            botuser.user_pref_lang) + '`',
         value=transget(
             "command.voice.help.toggle.description",
             botuser.user_pref_lang))
     embed.add_field(
-        name=transget(
+        name='`' + shortprefix + transget(
             "command.voice.help.name.syntax",
-            botuser.user_pref_lang),
+            botuser.user_pref_lang) + '`',
         value=transget(
             "command.voice.help.name.description",
             botuser.user_pref_lang))
     embed.add_field(
-        name=transget(
+        name='`' + shortprefix + transget(
             "command.voice.help.transfer.syntax",
-            botuser.user_pref_lang),
+            botuser.user_pref_lang) + '`',
         value=transget(
             "command.voice.help.transfer.description",
             botuser.user_pref_lang))
     embed.add_field(
-        name=transget(
+        name='`' + shortprefix + transget(
             "command.voice.help.invite.syntax",
-            botuser.user_pref_lang),
+            botuser.user_pref_lang) + '`',
         value=transget(
             "command.voice.help.invite.description",
             botuser.user_pref_lang))
     embed.add_field(
-        name=transget(
+        name='`' + shortprefix + transget(
             "command.voice.help.kick.syntax",
-            botuser.user_pref_lang),
+            botuser.user_pref_lang) + '`',
         value=transget(
             "command.voice.help.kick.description",
             botuser.user_pref_lang))
     embed.add_field(
-        name=transget(
+        name='`' + shortprefix + transget(
             "command.voice.help.close.syntax",
-            botuser.user_pref_lang),
+            botuser.user_pref_lang) + '`',
         value=transget(
             "command.voice.help.close.description",
             botuser.user_pref_lang))


### PR DESCRIPTION
This update brings changes to the DynVoice initial help message and fixes some other bugs with DynVoiceChannels

- Initial help now shows current shortprefix in front of commands (This was considered as redundand information before, but people are boosted and do not know that command prefixes are mandatory)
- The bot now does not spam the server with user role updates when they change their voice status without entering or leaving a DynVoiceChannel (watch a live screen broadcast, mute themselfs, activating screen share or webcam, toggling voice actions, toggle speech permissions, ...)
- Stop command now log the stop action again (but the CTRL+C signal handler is not)